### PR TITLE
fix: 修复文章详情toc内容超过浏览器可视高度无法跟随滚动问题。(#7)

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -43,10 +43,10 @@
             class="toc-container h-0 w-60 overflow-hidden rounded-lg border bg-white p-3 opacity-0 transition-all duration-300"
             style="font-size: 0"
           >
-            <div class="mb-2 flex items-center justify-between">
+            <div class="mb-2 flex items-center justify-between border-b border-solid pb-2">
               <h3 class="ml-1 text-base font-medium">文章目录</h3>
             </div>
-            <div id="toc" class="toc"></div>
+            <div id="toc" class="toc max-h-[calc(100vh-10rem)] overflow-y-auto"></div>
           </div>
 
           <!-- 图片列表 -->


### PR DESCRIPTION
 修复文章详情toc内容超过浏览器可视高度无法跟随滚动问题。
 
 Fix: ( #7 )
 
 修复前：
 
![PixPin_2025-12-16_01-32-51](https://github.com/user-attachments/assets/e2cebc26-b573-4e0f-a894-83448ed2b95c)

 
 修复后：
 
![PixPin_2025-12-16_01-31-41](https://github.com/user-attachments/assets/d9d087d0-338d-4607-81bb-8032a985cdc0)
