### PR TITLE
feat: 优化瞬间显示，修复内容渲染、优化图片展示、支持配置用户信息显示的位置、修复代码显示和 Shiki 代码高亮 冲突 (#9)

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -343,3 +343,12 @@ spec:
               value: true
             - label: 关闭
               value: false
+        - $formkit: select
+          name: userInfoPosition
+          label: 用户信息显示位置
+          value: "bottom"
+          options:
+            - label: 底部
+              value: "bottom"
+            - label: 顶部
+              value: "top"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,102 +1,124 @@
 html {
-    scroll-behavior: smooth;
+  scroll-behavior: smooth;
 }
 
 body {
-    background-color: #ffffff;
+  background-color: #ffffff;
 }
 
 ul {
-    list-style-type: none;
+  list-style-type: none;
 }
 
 .transition-main {
-    transition: all 0.3s !important;
+  transition: all 0.3s !important;
 }
 
 .mobile-handle-btn {
-    padding: 6px;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    background: transparent;
-    transition: all 0.15s;
+  padding: 6px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background: transparent;
+  transition: all 0.15s;
 }
 
 .active-menu {
-    color: #3B82F6;
+  color: #3B82F6;
 }
 
 .is-active-li {
-    color: #3B82F6;
-    background-color: #f3f4f6;
-    border-radius: 4px;
+  color: #3B82F6;
+  background-color: #f3f4f6;
+  border-radius: 4px;
 }
 
 .max-container-width {
-    max-width: 1400px;
+  max-width: 1400px;
 }
 
 .markdown-body {
 
-    ol,
-    ul,
-    menu {
-        list-style: disc !important;
-        list-style-type: disc !important;
-    }
+  ol,
+  ul,
+  menu {
+    list-style: disc !important;
+    list-style-type: disc !important;
+  }
 }
 
 /* 修复样式问题 */
 .inline-block:has(pre) {
-    display: block !important;
+  display: block !important;
 }
 
 pre code {
-    padding: 0px !important;
+  padding: 0px !important;
 }
 
 hyperlink-card {
-    margin-top: 0px !important;
-    margin-bottom: 1rem !important;
+  margin-top: 0px !important;
+  margin-bottom: 1rem !important;
 }
 
 * {
-    scrollbar-width: none;
+  scrollbar-width: none;
 }
 
 ::-webkit-scrollbar {
-    display: none;
+  display: none;
 }
 
 .transition-header-property {
-    transition-property: background-color, border-color;
+  transition-property: background-color, border-color;
 }
 
-.toc>.toc-list {
-    margin-left: 0px;
+.toc > .toc-list {
+  margin-left: 0px;
 }
 
 .toc-list {
-    margin-left: 1rem;
+  margin-left: 1rem;
 }
 
 .full-height {
-    height: 100vh;
+  height: 100vh;
 }
 
 @supports (height: 100dvh) {
-    .full-height {
-        height: 100dvh;
-    }
+  .full-height {
+    height: 100dvh;
+  }
 }
 
 .min-full-height {
-    min-height: 100vh;
+  min-height: 100vh;
 }
 
 @supports (min-height: 100dvh) {
-    .min-full-height {
-        min-height: 100dvh;
-    }
+  .min-full-height {
+    min-height: 100dvh;
+  }
+}
+
+/* 瞬间 */
+.moment-content {
+  font-size: 14px;
+}
+
+.moment-content .tag {
+  display: inline-flex;
+  border-radius: 9999px;
+  align-items: center;
+  column-gap: .25rem;
+  padding: .2rem .5rem;
+  font-size: .75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  background-color: rgba(59, 130, 246, 0.2);
+  color: rgba(59, 130, 246, 1);
+}
+
+.moment-content .tag::before {
+  content: "#";
 }

--- a/templates/moments.html
+++ b/templates/moments.html
@@ -13,14 +13,46 @@
             th:with="content=${moment.spec.content}"
             class="flex flex-wrap gap-2 rounded-lg border bg-white p-4 max-sm:p-3"
           >
-            <div th:if="${not #strings.isEmpty(content.html)}" th:utext="${content.html}" class="w-full"></div>
+            <div
+              th:if="${theme.config.moments.userInfoPosition=='top'}"
+              class="mb-2 flex w-full flex-wrap items-center gap-2 font-medium"
+            >
+              <div class="size-10 overflow-hidden rounded-full bg-gray-100">
+                <img
+                  class="h-full w-full transition-all hover:scale-105"
+                  width="40"
+                  height="40"
+                  th:src="${moment.owner.avatar}"
+                  th:alt="${moment.owner.displayName}"
+                />
+              </div>
+              <div class="flex flex-col gap-y-0.5">
+                <div th:text="${moment.owner.displayName}"></div>
+                <div
+                  class="text-xs opacity-50"
+                  th:text="${#dates.format(moment.spec.releaseTime, 'yyyy年MM月dd日 HH点mm分ss秒')}"
+                ></div>
+              </div>
+            </div>
+
+            <div
+              th:if="${not #strings.isEmpty(content.html)}"
+              th:utext="${content.html}"
+              class="markdown-body moment-content w-full"
+            ></div>
             <th:block th:if="${not #lists.isEmpty(content.medium)}" th:each="momentItem : ${content.medium}">
               <div
                 th:if="${momentItem.type.name == 'PHOTO'}"
-                class="mb-1 rounded-md border"
-                style="height: 124px; width: auto; overflow: hidden"
+                class="mb-1 w-full overflow-hidden rounded-md border md:h-[124px] md:w-auto"
               >
-                <img th:src="${momentItem.url}" style="height: 124px" />
+                <img
+                  class="w-full md:h-[124px] md:w-auto"
+                  th:src="${momentItem.url}"
+                  th:srcset="|${thumbnail.gen(momentItem.url, 's')} 400w,
+                             ${thumbnail.gen(momentItem.url, 'm')} 800w|"
+                  sizes="(max-width: 800px) 100vw, 800px"
+                  loading="lazy"
+                />
               </div>
               <div
                 style="height: 260px"
@@ -33,7 +65,11 @@
                 <audio th:src="${momentItem.url}" controls="true"></audio>
               </div>
             </th:block>
-            <div class="flex w-full flex-wrap gap-2 text-xs font-medium opacity-50">
+
+            <div
+              th:if="${theme.config.moments.userInfoPosition=='bottom'}"
+              class="flex w-full flex-wrap gap-2 text-xs font-medium opacity-50"
+            >
               <p th:text="'发布人：' + ${moment.spec.owner}"></p>
               <p th:text="'发布时间：' + ${#dates.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm:ss')}"></p>
             </div>
@@ -47,5 +83,31 @@
       <!-- 分页 -->
       <th:block th:replace="~{modules/moments/momentsPagination}"></th:block>
     </div>
+
+    <script th:inline="javascript">
+      (function () {
+        "use strict";
+
+        // --------- 开始 优化启用 shiki 插件的 右上角复制按钮样式冲突 ---------
+        function checkFixMarkdownStyle() {
+          const isAvailableShikiPlugin = /*[[${pluginFinder.available('shiki') }]]*/ false;
+          if (isAvailableShikiPlugin) {
+            const shikiCodeTags = document.querySelectorAll("shiki-code");
+            if (shikiCodeTags.length !== 0) {
+              const copyDomSelectors =
+                ".moment-content div[class='absolute top-2 right-2 flex items-center gap-2 z-10']";
+              document.querySelectorAll(copyDomSelectors).forEach(function (el) {
+                el.style.display = "none";
+              });
+            }
+          }
+        }
+        // --------- 结束 优化启用 shiki 插件的 右上角复制按钮样式冲突 ---------
+
+        window.addEventListener("DOMContentLoaded", function () {
+          checkFixMarkdownStyle();
+        });
+      })();
+    </script>
   </th:block>
 </html>


### PR DESCRIPTION
对于瞬间页面的优化：

fix(#9)

#### 1、修复内容样式渲染不生效问题。
![PixPin_2025-12-17_14-52-52](https://github.com/user-attachments/assets/fb3bffdd-0eae-4282-baea-26b21f03b1b5)


#### 2、修复内容渲染和 [Shiki 代码高亮](https://www.halo.run/store/apps/app-kzloktzn) 插件右上角复制按钮冲突问题。
![PixPin_2025-12-17_14-53-25](https://github.com/user-attachments/assets/4836e80b-bbbc-40f0-8c90-9fa01534d003)

#### 3、增加用户信息头像的显示，同时支持配置显示的位置（顶部和底部），顶部是新增的样式显示，底部是默认的原始的显示。
![PixPin_2025-12-17_14-53-45](https://github.com/user-attachments/assets/48692a18-ccab-4420-ae28-36e1a36d86cc)
![PixPin_2025-12-17_14-59-02](https://github.com/user-attachments/assets/08033e13-5c4f-4fe7-9842-b75c00a0f475)
![PixPin_2025-12-17_14-54-08](https://github.com/user-attachments/assets/435c9582-5cb2-4a8c-b4cb-f7e88e79cdca)


#### 4、优化图片附件的显示，在移动端中显示单列。

 - 原始：
![PixPin_2025-12-17_14-55-12](https://github.com/user-attachments/assets/d097c4d1-ea93-4b87-8654-c7f08aaa38c3)

- 调整：
![PixPin_2025-12-17_14-56-01](https://github.com/user-attachments/assets/9a08ee5e-0c22-48ea-9938-f11ac2abfb65)
